### PR TITLE
fixed Utils.encrypted_options to return nil instead of false

### DIFF
--- a/lib/lockbox/utils.rb
+++ b/lib/lockbox/utils.rb
@@ -18,7 +18,7 @@ class Lockbox
     end
 
     def self.encrypted_options(record, name)
-      record.class.respond_to?(:lockbox_attachments) && record.class.lockbox_attachments[name.to_sym]
+      record.class.respond_to?(:lockbox_attachments) ? record.class.lockbox_attachments[name.to_sym] : nil
     end
 
     def self.decode_key(key)


### PR DESCRIPTION
The `encrypted?` method was modified to check if the return value from `Utils.encrypted_options` is `nil`, but that method actually returns `false` if the attachment does not respond to :lockbox_attachments. Because of that, `encrypted?` returned `true` for attachments that were not encrypted.