### PR TITLE
improved check for OpenSSL::KDF

### DIFF
--- a/lib/lockbox/key_generator.rb
+++ b/lib/lockbox/key_generator.rb
@@ -16,24 +16,12 @@ class Lockbox
 
     private
 
-    def hasKDF()
-      if !instance_variable_defined?(:@hasKDF)
-        begin
-          Object.const_get('OpenSSL::KDF')
-          instance_variable_set(:@hasKDF, true)
-        rescue => x
-          instance_variable_set(:@hasKDF, false)
-        end
-      end
-      instance_variable_get(:@hasKDF)
-    end
-      
     def hash_hmac(hash, ikm, salt)
       OpenSSL::HMAC.digest(hash, salt, ikm)
     end
 
     def hkdf(ikm, salt:, info:, length:, hash:)
-      if hasKDF && OpenSSL::KDF.respond_to?(:hkdf)
+      if defined?(OpenSSL::KDF) && OpenSSL::KDF.respond_to?(:hkdf)
         return OpenSSL::KDF.hkdf(ikm, salt: salt, info: info, length: length, hash: hash)
       end
 

--- a/lib/lockbox/key_generator.rb
+++ b/lib/lockbox/key_generator.rb
@@ -15,25 +15,13 @@ class Lockbox
     end
 
     private
-
-    def hasKDF()
-      if !instance_variable_defined?(:@hasKDF)
-        begin
-          Object.const_get('OpenSSL::KDF')
-          instance_variable_set(:@hasKDF, true)
-        rescue => x
-          instance_variable_set(:@hasKDF, false)
-        end
-      end
-      instance_variable_get(:@hasKDF)
-    end
       
     def hash_hmac(hash, ikm, salt)
       OpenSSL::HMAC.digest(hash, salt, ikm)
     end
 
     def hkdf(ikm, salt:, info:, length:, hash:)
-      if hasKDF && OpenSSL::KDF.respond_to?(:hkdf)
+      if defined?(OpenSSL::KDF.hkdf)
         return OpenSSL::KDF.hkdf(ikm, salt: salt, info: info, length: length, hash: hash)
       end
 

--- a/lib/lockbox/key_generator.rb
+++ b/lib/lockbox/key_generator.rb
@@ -16,12 +16,24 @@ class Lockbox
 
     private
 
+    def hasKDF()
+      if !instance_variable_defined?(:@hasKDF)
+        begin
+          Object.const_get('OpenSSL::KDF')
+          instance_variable_set(:@hasKDF, true)
+        rescue => x
+          instance_variable_set(:@hasKDF, false)
+        end
+      end
+      instance_variable_get(:@hasKDF)
+    end
+      
     def hash_hmac(hash, ikm, salt)
       OpenSSL::HMAC.digest(hash, salt, ikm)
     end
 
     def hkdf(ikm, salt:, info:, length:, hash:)
-      if defined?(OpenSSL::KDF) && OpenSSL::KDF.respond_to?(:hkdf)
+      if hasKDF && OpenSSL::KDF.respond_to?(:hkdf)
         return OpenSSL::KDF.hkdf(ikm, salt: salt, info: info, length: length, hash: hash)
       end
 


### PR DESCRIPTION
Some openssl distributions (*e.g.* the openssl library on macOS Mojave) don't export the OpenSSL::KDF symbol