### PR TITLE
use unscoped model

### DIFF
--- a/lib/lockbox.rb
+++ b/lib/lockbox.rb
@@ -55,7 +55,7 @@ class Lockbox
           if i == 0
             relation.where(attribute => nil)
           else
-            relation.or(model.where(attribute => nil))
+            relation.or(relation.where(attribute => nil))
           end
       end
     end


### PR DESCRIPTION
Lockbox.migrate() throwing `ArgumentError (Relation passed to #or must be structurally compatible. Incompatible values: [:order])` if model contains an "order" clause in default_scope.