### PR TITLE
Decrypt after destroy

### DIFF
--- a/lib/lockbox/model.rb
+++ b/lib/lockbox/model.rb
@@ -267,7 +267,7 @@ module Lockbox
               @attributes[name.to_s].instance_variable_set("@value_before_type_cast", message) if @attributes[name.to_s]
 
               # cache
-              if respond_to?(:_write_attribute, true)
+              if respond_to?(:_write_attribute, true) && !@attributes.frozen?
                 _write_attribute(name, message)
               elsif respond_to?(:raw_write_attribute)
                 raw_write_attribute(name, message)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -8,7 +8,7 @@ class ActiveRecordTest < Minitest::Test
     assert_equal email, user.email
   end
 
-  def test_encrypt_after_destroy
+  def test_decrypt_after_destroy
     email = "test@example.org"
     User.create!(email: email)
 

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -8,6 +8,16 @@ class ActiveRecordTest < Minitest::Test
     assert_equal email, user.email
   end
 
+  def test_encrypt_after_destroy
+    email = "test@example.org"
+    User.create!(email: email)
+
+    user = User.last
+    user.destroy!
+
+    user.email
+  end
+
   def test_utf8
     email = "Łukasz"
     User.create!(email: email)


### PR DESCRIPTION
Lockbox produces the following error in my code:

I have an instance of an activerecord model. That model is deleted and is still used in the response rendering. In lib/lockbox/model.rb the value is cached on descryption but activerecords destroy freezes the attributes hash which is written to by activemodels _write_attribute. This breaks decryption on a destroyed model instance.