### PR TITLE
Add support for `attachment.open`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed decryption with Active Storage 6 and `attachment.open`
+
 ## 0.3.5 (2020-04-13)
 
 - Added `array` type

--- a/README.md
+++ b/README.md
@@ -843,5 +843,6 @@ To get started with development and testing:
 git clone https://github.com/ankane/lockbox.git
 cd lockbox
 bundle install
+brew install libsodium
 bundle exec rake test
 ```

--- a/test/active_storage_test.rb
+++ b/test/active_storage_test.rb
@@ -179,4 +179,14 @@ class ActiveStorageTest < Minitest::Test
     assert_equal message, post.photo.download
     assert_equal message, post.photo.blob.download
   end
+
+  def test_open
+    path = "test/support/image.png"
+    user = User.create!
+    user.avatar.attach(io: File.open(path), filename: "image.png", content_type: "image/png")
+
+    user.avatar.open do |f|
+      assert_equal File.binread(path), f.read
+    end
+  end
 end


### PR DESCRIPTION
`blob.open` is added as part of Rails 6 (Reference: https://blog.bigbinary.com/2019/10/30/rails-6-adds-activestorage-blob-open.html). 

This adds support for `attachment.open`. As with other ActiveStorage features for Lockbox, `blob.open` is not implemented since encryption is identified at the record level.
