### PR TITLE
Fix `#attributes` raising `ActiveModel::MissingAttributeError`

### DIFF
--- a/lib/lockbox/model.rb
+++ b/lib/lockbox/model.rb
@@ -87,6 +87,13 @@ module Lockbox
                 # essentially a no-op if already loaded
                 # an exception is thrown if decryption fails
                 self.class.lockbox_attributes.each do |_, lockbox_attribute|
+                  # it is possible that the encrypted attribute is not loaded, eg.
+                  # if the record was fetched partially (`User.select(:id).first`).
+                  # accessing a not loaded attribute raises an `ActiveModel::MissingAttributeError`.
+                  # `respond_to?` actually returns `false` in activerecord if an attribute was not
+                  # loaded, so we do not try to decrypt it in this case.
+                  next unless respond_to?(lockbox_attribute[:encrypted_attribute])
+
                   send(lockbox_attribute[:attribute])
                 end
                 super

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -207,6 +207,14 @@ class ModelTest < Minitest::Test
     assert_equal "test@example.org", user.attributes["email"]
   end
 
+  def test_attributes_not_loaded
+    skip if mongoid?
+
+    User.create!(email: "test@example.org")
+    user = User.select('id').last
+    assert_nil user.attributes['email']
+  end
+
   def test_attributes_bad_ciphertext
     skip if mongoid?
 


### PR DESCRIPTION
When a record is loaded partially without the ciphertext, e.g. `User.select(:id).first`, trying to access the not loaded column leads to an `ActiveModel::MissingAttributeError`.

Lockbox always was trying to decrypt all attributes, even the not loaded ones. Make sure only loaded encrypted attributes get decrypted.