### PR TITLE
Fixed ActiveStorage compatibility with empty files

### DIFF
--- a/lib/lockbox/active_storage_extensions.rb
+++ b/lib/lockbox/active_storage_extensions.rb
@@ -103,7 +103,7 @@ module Lockbox
         # as earlier versions of Lockbox won't have it
         # and it's not a good practice to trust modifiable data
         encrypted = options && (!options[:migrating] || blob.metadata["encrypted"])
-        if encrypted
+        if encrypted && !result.empty?
           result = Utils.decrypt_result(record, name, options, result)
         end
 
@@ -128,7 +128,7 @@ module Lockbox
             # as earlier versions of Lockbox won't have it
             # and it's not a good practice to trust modifiable data
             encrypted = options && (!options[:migrating] || blob.metadata["encrypted"])
-            if encrypted
+            if encrypted && !file.eof?
               result = Utils.decrypt_result(record, name, options, file.read)
               file.rewind
               # truncate may not be available on all platforms

--- a/lib/lockbox/utils.rb
+++ b/lib/lockbox/utils.rb
@@ -60,6 +60,8 @@ module Lockbox
         case attachable
         when ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile
           io = attachable
+          return attachable if io.eof?
+
           attachable = {
             io: box.encrypt_io(io),
             filename: attachable.original_filename,
@@ -67,6 +69,8 @@ module Lockbox
           }
         when Hash
           io = attachable[:io]
+          return attachable if attachable[:io].eof?
+
           attachable = attachable.dup
           attachable[:io] = box.encrypt_io(io)
         else

--- a/test/active_storage_test.rb
+++ b/test/active_storage_test.rb
@@ -33,6 +33,26 @@ class ActiveStorageTest < Minitest::Test
     refute_equal content, user.avatar.blob.download
   end
 
+  def test_encrypt_blank_one
+    user = User.create!(avatar: attachment(""))
+    assert_equal "", user.avatar.download
+    assert_equal "", user.avatar.blob.download
+
+    user = User.last
+    assert_equal "", user.avatar.download
+    assert_equal "", user.avatar.blob.download
+  end
+
+  def test_encrypt_blank_uploaded_file
+    user = User.create!(avatar: uploaded_file(""))
+    assert_equal "", user.avatar.download
+    assert_equal "", user.avatar.blob.download
+
+    user = User.last
+    assert_equal "", user.avatar.download
+    assert_equal "", user.avatar.blob.download
+  end
+
   def test_encrypt_blob
     user = User.create!(avatar: attachment)
 
@@ -247,6 +267,15 @@ class ActiveStorageTest < Minitest::Test
     end
   end
 
+  def test_open_blank
+    skip if ActiveStorage::VERSION::MAJOR < 6
+
+    user = User.create!(avatar: attachment(""))
+    user.avatar.open do |f|
+      assert_equal "", f.read
+    end
+  end
+
   def test_metadata
     user = User.create!
 
@@ -403,7 +432,8 @@ class ActiveStorageTest < Minitest::Test
     contents.map { |c| attachment(c) }
   end
 
-  def uploaded_file
+  def uploaded_file(content = nil)
+    content ||= self.content
     file = Tempfile.new
     file.write(content)
     file.rewind


### PR DESCRIPTION
Previously, Lockbox would break if an empty file was uploaded. This change bypasses encryption/decryption for empty files.