### PR TITLE
Support procs/symbols for previous_key

### DIFF
--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -29,7 +29,7 @@ class User < ActiveRecord::Base
   mount_uploaders :documents, DocumentUploader
   serialize :documents, JSON
 
-  encrypts :email, previous_versions: [{key: Lockbox.generate_key}, {master_key: Lockbox.generate_key}]
+  encrypts :email, previous_versions: [{key: ->{Lockbox.generate_key}}, {master_key: Lockbox.generate_key}]
 
   key_pair = Lockbox.generate_key_pair
   encrypts :phone, algorithm: "hybrid", encryption_key: key_pair[:encryption_key], decryption_key: key_pair[:decryption_key]


### PR DESCRIPTION
This allows us to provide `previous_key` with the same kinds of options as we are currently able to for `key`.

For my own use case, I'm looking to support dynamic key rotation where I have a current key and previous key on an associated model, and want to write in my (ActiveRecord) model something like this:

```
  encrypts :value,
    key: -> { account.key },
    previous_versions: [{ key: -> { account.previous_key } }]
```
