### PR TITLE
Update pluck for migrating existing data

### DIFF
--- a/lib/lockbox/calculations.rb
+++ b/lib/lockbox/calculations.rb
@@ -3,7 +3,10 @@ module Lockbox
     def pluck(*column_names)
       return super unless model.respond_to?(:lockbox_attributes)
 
-      lockbox_columns = column_names.map.with_index { |c, i| [model.lockbox_attributes[c.to_sym], i] }.select(&:first)
+      lockbox_columns = column_names.map
+                                    .with_index { |c, i| [model.lockbox_attributes[c.to_sym], i] }
+                                    .select(&:first)
+                                    .reject { |la, _i| la.fetch(:migrating, false) }
       return super unless lockbox_columns.any?
 
       # replace column with ciphertext column

--- a/lib/lockbox/calculations.rb
+++ b/lib/lockbox/calculations.rb
@@ -3,10 +3,8 @@ module Lockbox
     def pluck(*column_names)
       return super unless model.respond_to?(:lockbox_attributes)
 
-      lockbox_columns = column_names.map
-                                    .with_index { |c, i| [model.lockbox_attributes[c.to_sym], i] }
-                                    .select(&:first)
-                                    .reject { |la, _i| la.fetch(:migrating, false) }
+      lockbox_columns = column_names.map.with_index { |c, i| [model.lockbox_attributes[c.to_sym], i] }.select { |la, _i| la && !la[:migrating] }
+
       return super unless lockbox_columns.any?
 
       # replace column with ciphertext column

--- a/test/pluck_test.rb
+++ b/test/pluck_test.rb
@@ -58,21 +58,7 @@ class PluckTest < Minitest::Test
     Robot.create!(name: "Test 1", email: "test1@example.org")
     Robot.create!(name: "Test 2", email: "test2@example.org")
 
-    # migrated
-    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:name)
-    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:id, :name).map(&:last)
-    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], Robot.order(:id).pluck(:name, :email)
-
-    # half migrated
     Robot.update_all(name_ciphertext: nil)
     assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:name)
-    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:id, :name).map(&:last)
-    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], Robot.order(:id).pluck(:name, :email)
-
-    # not migrated
-    Robot.update_all(name_ciphertext: nil, email_ciphertext: nil)
-    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:name)
-    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:id, :name).map(&:last)
-    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], Robot.order(:id).pluck(:name, :email)
   end
 end

--- a/test/pluck_test.rb
+++ b/test/pluck_test.rb
@@ -5,6 +5,7 @@ class PluckTest < Minitest::Test
     skip if mongoid?
 
     User.delete_all
+    Robot.delete_all
   end
 
   def test_symbol
@@ -51,5 +52,27 @@ class PluckTest < Minitest::Test
       Admin.pluck(:email)
     end
     assert_equal "Not available since :key depends on record", error.message
+  end
+
+  def test_migrating
+    Robot.create!(name: "Test 1", email: "test1@example.org")
+    Robot.create!(name: "Test 2", email: "test2@example.org")
+
+    # migrated
+    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:name)
+    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:id, :name).map(&:last)
+    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], Robot.order(:id).pluck(:name, :email)
+
+    # half migrated
+    Robot.update_all(name_ciphertext: nil)
+    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:name)
+    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:id, :name).map(&:last)
+    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], Robot.order(:id).pluck(:name, :email)
+
+    # not migrated
+    Robot.update_all(name_ciphertext: nil, email_ciphertext: nil)
+    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:name)
+    assert_equal ["Test 1", "Test 2"], Robot.order(:id).pluck(:id, :name).map(&:last)
+    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], Robot.order(:id).pluck(:name, :email)
   end
 end


### PR DESCRIPTION
This addresses #79 👋 

#### Issue 🔥
While migrating existing data, `pluck` may falsely return `nil` for old records where the data from existing, unencrypted columns hasn't yet been migrated to the new encrypted `_ciphertext` columns.

#### Solution 💡
As suggested by @ankane in https://github.com/ankane/lockbox/issues/79#issuecomment-730538698: adjust lockbox' implementation of `pluck` to exclude attributes marked with `migrating: true` from any special treatment other lockbox attributes get there. Instead, attributes marked with `migrating: true` will be treated like any other unencrypted attributes.

Doing so, `pluck` will fall back to the original, unencrypted columns for attributes marked as `migrating: true`, until `migrating` is set to `false` (speaking: removed from the attribute configuration) and the encrypted columns are the no. 1 source of truth for the attribute.

#### Note ✏️
I could not find a specific guide for contributions, so I just tried to keep the change as small but explicit as possible for both, the implementation and the tests 🤷.

Happy to fine tune this further of course 🙇 