### PR TITLE
Clarify master key instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ lockbox:
   master_key: "0000000000000000000000000000000000000000000000000000000000000000"
 ```
 
-or create `config/initializers/lockbox.rb` with something like
+and then set the key in an initializer `config/initializers/lockbox.rb` with something like
 
 ```ruby
 Lockbox.master_key = Rails.application.credentials.lockbox[:master_key]


### PR DESCRIPTION
Currently, the instructions are not clear that if the key is set in Rails Credentials, you **must** explicitly set `Lockbox.master_key` to the credential in an initializer.  