### PR TITLE
Fix issue where edge rails removes write_attribute_without_type_cast and implements default variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
         - ruby: 3.0
           gemfile: Gemfile
         - ruby: 2.7
+          gemfile: gemfiles/rails70.gemfile
+        - ruby: 2.7
           gemfile: gemfiles/rails60.gemfile
         - ruby: 2.6
           gemfile: gemfiles/rails52.gemfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         - ruby: 3.0
           gemfile: Gemfile
         - ruby: 2.7
-          gemfile: gemfiles/rails70.gemfile
+          gemfile: gemfiles/railsedge.gemfile
         - ruby: 2.7
           gemfile: gemfiles/rails60.gemfile
         - ruby: 2.6

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -1,0 +1,16 @@
+source "https://rubygems.org"
+
+gemspec path: ".."
+
+gem "rake"
+gem "minitest", ">= 5"
+
+# This is the Rails 7.0.0.alpha commmit where Lockbox begins breaking
+gem 'rails', github: 'rails/rails', ref: '14ff158e73f17d2cb76f89f0d8c84a556f7589d9'
+gem "carrierwave"
+gem "combustion", ">= 1.3"
+gem "rbnacl", ">= 6"
+gem "sqlite3"
+gem "pg"
+gem "mysql2"
+gem "shrine"

--- a/gemfiles/railsedge.gemfile
+++ b/gemfiles/railsedge.gemfile
@@ -5,8 +5,7 @@ gemspec path: ".."
 gem "rake"
 gem "minitest", ">= 5"
 
-# This is the Rails 7.0.0.alpha commmit where Lockbox begins breaking
-gem 'rails', github: 'rails/rails', ref: '14ff158e73f17d2cb76f89f0d8c84a556f7589d9'
+gem "rails", github: "rails/rails", branch: "main"
 gem "carrierwave"
 gem "combustion", ">= 1.3"
 gem "rbnacl", ">= 6"

--- a/lib/lockbox/model.rb
+++ b/lib/lockbox/model.rb
@@ -192,7 +192,9 @@ module Lockbox
                 # same logic as Active Record
                 # (although this happens before saving)
                 attributes_to_set.each do |k, v|
-                  if respond_to?(:raw_write_attribute, true)
+                  if respond_to?(:write_attribute_without_type_cast, true)
+                    write_attribute_without_type_cast(k, v)
+                  elsif respond_to?(:raw_write_attribute, true)
                     raw_write_attribute(k, v)
                   else
                     @attributes.write_cast_value(k, v)
@@ -261,7 +263,7 @@ module Lockbox
                   attribute name, ActiveRecord::Type::Serialized.new(ActiveRecord::Type::String.new, attribute_type.coder)
                 end
               elsif ActiveRecord::VERSION::STRING.to_f >= 6.1 && attributes_to_define_after_schema_loads[name.to_s].first.is_a?(Proc)
-                attribute_type = attributes_to_define_after_schema_loads[name.to_s].first.call(nil)
+                attribute_type = attributes_to_define_after_schema_loads[name.to_s].first.call
                 if attribute_type.is_a?(ActiveRecord::Type::Serialized) && attribute_type.subtype.nil?
                   attribute name, ActiveRecord::Type::Serialized.new(ActiveRecord::Type::String.new, attribute_type.coder)
                 end
@@ -387,7 +389,9 @@ module Lockbox
 
                 # cache
                 # decrypt method does type casting
-                if respond_to?(:raw_write_attribute, true)
+                if respond_to?(:write_attribute_without_type_cast, true)
+                  write_attribute_without_type_cast(name.to_s, message) if !@attributes.frozen?
+                elsif respond_to?(:raw_write_attribute, true)
                   raw_write_attribute(name, message) if !@attributes.frozen?
                 else
                   if !@attributes.frozen?

--- a/lib/lockbox/model.rb
+++ b/lib/lockbox/model.rb
@@ -192,10 +192,11 @@ module Lockbox
                 # same logic as Active Record
                 # (although this happens before saving)
                 attributes_to_set.each do |k, v|
-                  if respond_to?(:write_attribute_without_type_cast, true)
-                    write_attribute_without_type_cast(k, v)
-                  else
+                  if respond_to?(:raw_write_attribute, true)
                     raw_write_attribute(k, v)
+                  else
+                    @attributes.write_cast_value(k, v)
+                    clear_attribute_change(k)
                   end
                 end
 
@@ -254,8 +255,13 @@ module Lockbox
               # otherwise, type gets set to ActiveModel::Type::Value
               # which always returns false for changed_in_place?
               # earlier versions of Active Record take the previous code path
-              if ActiveRecord::VERSION::STRING.to_f >= 6.1 && attributes_to_define_after_schema_loads[name.to_s].first.is_a?(Proc)
-                attribute_type = attributes_to_define_after_schema_loads[name.to_s].first.call
+              if ActiveRecord::VERSION::STRING.to_f >= 7.0 && attributes_to_define_after_schema_loads[name.to_s].first.is_a?(Proc)
+                attribute_type = attributes_to_define_after_schema_loads[name.to_s].first.call(nil)
+                if attribute_type.is_a?(ActiveRecord::Type::Serialized) && attribute_type.subtype.nil?
+                  attribute name, ActiveRecord::Type::Serialized.new(ActiveRecord::Type::String.new, attribute_type.coder)
+                end
+              elsif ActiveRecord::VERSION::STRING.to_f >= 6.1 && attributes_to_define_after_schema_loads[name.to_s].first.is_a?(Proc)
+                attribute_type = attributes_to_define_after_schema_loads[name.to_s].first.call(nil)
                 if attribute_type.is_a?(ActiveRecord::Type::Serialized) && attribute_type.subtype.nil?
                   attribute name, ActiveRecord::Type::Serialized.new(ActiveRecord::Type::String.new, attribute_type.coder)
                 end
@@ -381,10 +387,13 @@ module Lockbox
 
                 # cache
                 # decrypt method does type casting
-                if respond_to?(:write_attribute_without_type_cast, true)
-                  write_attribute_without_type_cast(name.to_s, message) if !@attributes.frozen?
-                else
+                if respond_to?(:raw_write_attribute, true)
                   raw_write_attribute(name, message) if !@attributes.frozen?
+                else
+                  if !@attributes.frozen?
+                    @attributes.write_cast_value(name.to_s, message)
+                    clear_attribute_change(name)
+                  end
                 end
               else
                 instance_variable_set("@#{name}", message)

--- a/lib/lockbox/railtie.rb
+++ b/lib/lockbox/railtie.rb
@@ -19,7 +19,15 @@ module Lockbox
         ActiveStorage::Attached::Many.prepend(Lockbox::ActiveStorageExtensions::AttachedMany)
 
         # use load hooks when possible
-        if ActiveStorage::VERSION::MAJOR >= 6
+
+        if ActiveStorage::VERSION::MAJOR >= 7
+          ActiveSupport.on_load(:active_storage_attachment) do
+            prepend Lockbox::ActiveStorageExtensions::Attachment
+          end
+          ActiveSupport.on_load(:active_storage_blob) do
+            prepend Lockbox::ActiveStorageExtensions::Blob
+          end
+        elsif ActiveStorage::VERSION::MAJOR >= 6
           ActiveSupport.on_load(:active_storage_attachment) do
             include Lockbox::ActiveStorageExtensions::Attachment
           end


### PR DESCRIPTION
This PR addresses the following two issues:

-  Edge Rails commit breaks Lockbox's use of #write_attribute_without_type_cast #101
- Rails 7 ActiveStorage introduces predefined variants which breaks Lockbox's variant handling #102

Both issues are related to upcoming changes in Rails 7.

Specifically:

- Rails removes #write_attribute_without_type_cast 
- Rails modifies ActiveStorage with default variants

I've added a rails70.gemfile in case you want to add it to your CI pipeline.

Let me know!

Thanks!