### PR TITLE
Feat: Add example for decrypt data after rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,30 @@ end
 
 Finally, drop the unencrypted column.
 
+```ruby
+class RemoveEmailFromUsers < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :users, :email, :text
+  end
+
+  def down
+    add_column :users, :email, :text
+
+    decrypt_email
+  end
+
+  def decrypt_email
+    User.all.each do |user|
+      unless user.email.nil?
+        execute <<-SQL
+          UPDATE users SET email=#{user.email} WHERE id=#{user.id};
+        SQL
+      end
+    end
+  end
+end
+```
+
 If adding blind indexes, mark them as `migrating` during this process as well.
 
 ```ruby


### PR DESCRIPTION
I think it would be useful to add one more example for restoring data after a rollback migration.
While working with `lockbox`, I often had to switch to other branches of development and this led to loss data after rollback, after some time I decided to rewrite my migration and add decrypt method for restoring data, hope it will be useful to others as well.