### PR TITLE
skip attribute Unless it's proper attribute.

### DIFF
--- a/lib/lockbox/calculations.rb
+++ b/lib/lockbox/calculations.rb
@@ -3,7 +3,13 @@ module Lockbox
     def pluck(*column_names)
       return super unless model.respond_to?(:lockbox_attributes)
 
-      lockbox_columns = column_names.map.with_index { |c, i| [model.lockbox_attributes[c.to_sym], i] }.select { |la, _i| la && !la[:migrating] }
+      lockbox_columns = column_names.map.with_index do |c, i|
+        next unless c.is_a?(String) || c.is_a?(Symbol)
+
+        [model.lockbox_attributes[c.to_sym], i]
+      end.select do |la, _i|
+        la && !la[:migrating]
+      end
 
       return super unless lockbox_columns.any?
 


### PR DESCRIPTION
With this code I've fixed the issue with invoking:

```ruby
Model.pluck :id, :name, Arel::Nodes::Quoted.new('u')
```

Probably there could be a better way.
Please review. 
Thanks