### PR TITLE
Add Associated Data to Models

### DIFF
--- a/lib/lockbox/calculations.rb
+++ b/lib/lockbox/calculations.rb
@@ -12,16 +12,16 @@ module Lockbox
 
       return super unless lockbox_columns.any?
 
-      associated_columns_names = column_names.dup
+      associated_columns_names = []
       # replace column with ciphertext column
       lockbox_columns.each do |la, i|
         column_names[i] = la[:encrypted_attribute]
-        associated_columns_names[i] = la[:with_associated_field] if la[:with_associated_field]
+        associated_columns_names.push(la[:with_associated_field]) if la[:with_associated_field]
       end
 
       # pluck
-      all_columns = (column_names + associated_columns_names).compact.uniq
-      result = super(*column_names + associated_columns_names)
+      all_columns = (column_names + associated_columns_names).map(&:to_s).compact.uniq
+      result = super(*all_columns)
       result_hash = result.map { |fields| all_columns.zip(fields).to_h }
 
       # decrypt result
@@ -29,14 +29,14 @@ module Lockbox
       #
       # we can't pass context to decrypt method
       # so this won't work if any options are a symbol or proc
-
       lockbox_columns.each do |la, i|
         encrypted_attr = la[:encrypted_attribute]
-        associated_attr = la[:with_associated_field]
+        associated_attr = la[:with_associated_field] || nil
         result_hash.each do |record|
           record[encrypted_attr] = model.send("decrypt_#{la[:encrypted_attribute]}", record[encrypted_attr], record[associated_attr].to_s || '')
         end
       end
+
       result = result_hash.map { |record| record.slice(*column_names).values }
       result.flatten! if column_names.size == 1
       result

--- a/lib/lockbox/calculations.rb
+++ b/lib/lockbox/calculations.rb
@@ -22,7 +22,14 @@ module Lockbox
       # pluck
       all_columns = (column_names + associated_columns_names).map(&:to_s).compact.uniq
       result = super(*all_columns)
-      result_hash = result.map { |fields| all_columns.zip(fields).to_h }
+      result_hash = result.map do |fields|
+        if all_columns.length == 1
+          column_name = all_columns.first
+          { column_name => fields }
+        else
+          all_columns.zip(fields).to_h
+        end
+      end
 
       # decrypt result
       # handle pluck to single columns and multiple
@@ -37,7 +44,7 @@ module Lockbox
         end
       end
 
-      result = result_hash.map { |record| record.slice(*column_names).values }
+      result = result_hash.map { |record| record.slice(*column_names.map(&:to_s)).values }
       result.flatten! if column_names.size == 1
       result
     end

--- a/lib/lockbox/calculations.rb
+++ b/lib/lockbox/calculations.rb
@@ -12,30 +12,33 @@ module Lockbox
 
       return super unless lockbox_columns.any?
 
+      associated_columns_names = column_names.dup
       # replace column with ciphertext column
       lockbox_columns.each do |la, i|
         column_names[i] = la[:encrypted_attribute]
+        associated_columns_names[i] = la[:with_associated_field] if la[:with_associated_field]
       end
 
       # pluck
-      result = super(*column_names)
+      all_columns = (column_names + associated_columns_names).compact.uniq
+      result = super(*column_names + associated_columns_names)
+      result_hash = result.map { |fields| all_columns.zip(fields).to_h }
 
       # decrypt result
       # handle pluck to single columns and multiple
       #
       # we can't pass context to decrypt method
       # so this won't work if any options are a symbol or proc
-      if column_names.size == 1
-        la = lockbox_columns.first.first
-        result.map! { |v| model.send("decrypt_#{la[:encrypted_attribute]}", v) }
-      else
-        lockbox_columns.each do |la, i|
-          result.each do |v|
-            v[i] = model.send("decrypt_#{la[:encrypted_attribute]}", v[i])
-          end
+
+      lockbox_columns.each do |la, i|
+        encrypted_attr = la[:encrypted_attribute]
+        associated_attr = la[:with_associated_field]
+        result_hash.each do |record|
+          record[encrypted_attr] = model.send("decrypt_#{la[:encrypted_attribute]}", record[encrypted_attr], record[associated_attr].to_s || '')
         end
       end
-
+      result = result_hash.map { |record| record.slice(*column_names).values }
+      result.flatten! if column_names.size == 1
       result
     end
   end

--- a/lib/lockbox/migrator.rb
+++ b/lib/lockbox/migrator.rb
@@ -129,8 +129,10 @@ module Lockbox
       if rotate
         records.each do |record|
           fields.each do |k, v|
+            associated_field = v.fetch(:with_associated_field, nil)
             # update encrypted attribute directly to skip blind index computation
-            record.send("lockbox_direct_#{k}=", record.send(k))
+            associated_value = associated_field ? record.attributes[associated_field] : nil
+            record.send("lockbox_direct_#{k}=", record.send(k), associated_value || nil)
           end
         end
       else

--- a/lib/lockbox/model.rb
+++ b/lib/lockbox/model.rb
@@ -43,6 +43,11 @@ module Lockbox
         raise ArgumentError, "Associated Field cannot be the same field being encrypted (#{options[:with_associated_field]})"
       end
 
+      algorithm_selected = options.fetch(:algorithm, nil) || Lockbox.default_options.fetch(:algorithm, nil)
+      if options.key?(:with_associated_field) && (algorithm_selected == 'xsalsa20' || algorithm_selected == 'hybrid')
+        raise ArgumentError, "Associated Field cannot be used with algorithm xsalsa20 or hybrid"
+      end
+
       original_options = options.dup
 
       attributes.each do |name|

--- a/test/insert_test.rb
+++ b/test/insert_test.rb
@@ -8,47 +8,68 @@ class InsertTest < Minitest::Test
   end
 
   def test_insert
-    User.insert({name: "Test", email: "test@example.org"})
-    User.insert({"name" => "New", "email" => "new@example.org"})
+    _, err = capture_io do
+      User.insert({name: "Test", email: "test@example.org", password: "testpassword"})
+      User.insert({"name" => "New", "email" => "new@example.org", "password" => "newpassword"})
+    end
+    assert_match "[lockbox] Unable to associate id for password", err
 
-    users = User.order(:id).pluck(:name, :email)
-    expected = [["Test", "test@example.org"], ["New", "new@example.org"]]
+    users = User.order(:id).pluck(:name, :email, :password)
+    expected = [["Test", "test@example.org", nil], ["New", "new@example.org", nil]]
     assert_equal expected, users
   end
 
   def test_insert_all
-    User.insert_all([{name: "Test", email: "test@example.org"}])
-    User.insert_all([{"name" => "New", "email" => "new@example.org"}])
+    _, err = capture_io do
+      User.insert_all([{name: "Test", email: "test@example.org", password: "testpassword"}])
+      User.insert_all([{"name" => "New", "email" => "new@example.org", "password" => "newpassword"}])
+    end
+    assert_match "[lockbox] Unable to associate id for password", err
 
-    users = User.order(:id).pluck(:name, :email)
-    expected = [["Test", "test@example.org"], ["New", "new@example.org"]]
+    users = User.order(:id).pluck(:name, :email, :password)
+    expected = [["Test", "test@example.org", nil], ["New", "new@example.org", nil]]
     assert_equal expected, users
   end
 
   def test_insert_all!
-    User.insert_all!([{name: "Test", email: "test@example.org"}])
-    User.insert_all!([{"name" => "New", "email" => "new@example.org"}])
+    _, err = capture_io do
+      User.insert_all!([{name: "Test", email: "test@example.org", password: "testpassword"}])
+      User.insert_all!([{"name" => "New", "email" => "new@example.org", "password" => "newpassword"}])
+    end
+    assert_match "[lockbox] Unable to associate id for password", err
 
-    users = User.order(:id).pluck(:name, :email)
-    expected = [["Test", "test@example.org"], ["New", "new@example.org"]]
+    users = User.order(:id).pluck(:name, :email, :password)
+    expected = [["Test", "test@example.org", nil], ["New", "new@example.org", nil]]
+    assert_equal expected, users
+  end
+
+
+  def test_insert_all_with_ids!
+    _, err = capture_io do
+      User.insert_all!([{id: 1, name: "Test", email: "test@example.org", password: "testpassword"}])
+      User.insert_all!([{id: 2, "name" => "New", "email" => "new@example.org", "password" => "newpassword"}])
+    end
+
+    users = User.order(:id).pluck(:name, :email, :password)
+    expected = [["Test", "test@example.org", "testpassword"], ["New", "new@example.org", "newpassword"]]
     assert_equal expected, users
   end
 
   def test_upsert
-    User.upsert({id: 1, name: "Test", email: "test@example.org"})
-    User.upsert({"id" => 1, "name" => "New", "email" => "new@example.org"})
+    User.upsert({id: 1, name: "Test", email: "test@example.org", password: "testpassword"})
+    User.upsert({"id" => 1, "name" => "New", "email" => "new@example.org", "password" => "newpassword"})
 
-    users = User.order(:id).pluck(:name, :email)
-    expected = [["New", "new@example.org"]]
+    users = User.order(:id).pluck(:name, :email, :password)
+    expected = [["New", "new@example.org", "newpassword"]]
     assert_equal expected, users
   end
 
   def test_upsert_all
-    User.upsert_all([{id: 1, name: "Test", email: "test@example.org"}])
-    User.upsert_all([{"id" => 1, "name" => "New", "email" => "new@example.org"}])
+    User.upsert_all([{id: 1, name: "Test", email: "test@example.org", password: "testpassword"}])
+    User.upsert_all([{"id" => 1, "name" => "New", "email" => "new@example.org", "password" => "newpassword"}])
 
-    users = User.order(:id).pluck(:name, :email)
-    expected = [["New", "new@example.org"]]
+    users = User.order(:id).pluck(:name, :email, :password)
+    expected = [["New", "new@example.org", "newpassword"]]
     assert_equal expected, users
   end
 

--- a/test/internal/db/schema.rb
+++ b/test/internal/db/schema.rb
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define do
     t.text :photo_data
 
     t.text :password_ciphertext
+    t.text :balance_ciphertext
   end
 
   create_table :posts do |t|
@@ -114,6 +115,10 @@ ActiveRecord::Schema.define do
     t.text :other_email_ciphertext
     t.text :email_address_ciphertext
     t.text :encrypted_email
+
+    t.text :encrypted_password
+    t.text :balance_ciphertext
+    t.text :age_ciphertext
   end
 
   create_table :agents do |t|

--- a/test/internal/db/schema.rb
+++ b/test/internal/db/schema.rb
@@ -85,6 +85,8 @@ ActiveRecord::Schema.define do
     t.text :state
     t.text :state_ciphertext
     t.text :photo_data
+
+    t.text :password_ciphertext
   end
 
   create_table :posts do |t|
@@ -95,9 +97,11 @@ ActiveRecord::Schema.define do
     t.text :name
     t.text :email
     t.text :properties
+    t.text :password
     t.text :name_ciphertext
     t.text :email_ciphertext
     t.text :properties_ciphertext
+    t.text :password_ciphertext
   end
 
   create_table :comments do |t|

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -251,11 +251,11 @@ class ModelTypesTest < Minitest::Test
     Person.create!(data: {"count" => 0})
 
     person = Person.last
-    assert_equal 1, person.data["count"]
+    assert_equal 2, person.data["count"]
     person.save!
 
     person = Person.last
-    assert_equal 2, person.data["count"]
+    assert_equal 3, person.data["count"]
   end
 
   def test_json_save_twice

--- a/test/pluck_test.rb
+++ b/test/pluck_test.rb
@@ -10,8 +10,8 @@ class PluckTest < Minitest::Test
   end
 
   def test_symbol
-    User.create!(name: "Test 1", email: "test1@example.org")
-    User.create!(name: "Test 2", email: "test2@example.org")
+    User.create!(name: "Test 1", email: "test1@example.org", password: "password1")
+    User.create!(name: "Test 2", email: "test2@example.org", password: "password2")
 
     # unencrypted
     assert_equal ["Test 1", "Test 2"], User.order(:id).pluck(:name)
@@ -21,16 +21,21 @@ class PluckTest < Minitest::Test
     assert_equal ["test1@example.org", "test2@example.org"], User.order(:id).pluck(:email)
     assert_equal ["test1@example.org", "test2@example.org"], User.order(:id).pluck(:id, :email).map(&:last)
 
+    # encrypted associated
+    assert_equal ["password1", "password2"], User.order(:id).pluck(:password)
+    assert_equal ["password1", "password2"], User.order(:id).pluck(:id, :password).map(&:last)
+
     # multiple
-    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], User.order(:id).pluck(:name, :email)
+    assert_equal [["Test 1", "test1@example.org", "password1"], ["Test 2", "test2@example.org", "password2"]], User.order(:id).pluck(:name, :email, :password)
 
     # where
     assert_equal ["test2@example.org"], User.where(name: "Test 2").pluck(:email)
+    assert_equal ["password2"], User.where(name: "Test 2").pluck(:password)
   end
 
   def test_string
-    User.create!(name: "Test 1", email: "test1@example.org")
-    User.create!(name: "Test 2", email: "test2@example.org")
+    User.create!(name: "Test 1", email: "test1@example.org", password: "password1")
+    User.create!(name: "Test 2", email: "test2@example.org", password: "password2")
 
     # unencrypted
     assert_equal ["Test 1", "Test 2"], User.order(:id).pluck("name")
@@ -40,11 +45,16 @@ class PluckTest < Minitest::Test
     assert_equal ["test1@example.org", "test2@example.org"], User.order(:id).pluck("email")
     assert_equal ["test1@example.org", "test2@example.org"], User.order(:id).pluck("id", "email").map(&:last)
 
+    # encrypted associated
+    assert_equal ["password1", "password2"], User.order(:id).pluck("password")
+    assert_equal ["password1", "password2"], User.order(:id).pluck("id", "password").map(&:last)
+
     # multiple
-    assert_equal [["Test 1", "test1@example.org"], ["Test 2", "test2@example.org"]], User.order(:id).pluck("name", "email")
+    assert_equal [["Test 1", "test1@example.org", "password1"], ["Test 2", "test2@example.org", "password2"]], User.order(:id).pluck("name", "email", "password")
 
     # where
     assert_equal ["test2@example.org"], User.where(name: "Test 2").pluck("email")
+    assert_equal ["password2"], User.where(name: "Test 2").pluck("password")
   end
 
   def test_object

--- a/test/rotate_test.rb
+++ b/test/rotate_test.rb
@@ -7,7 +7,7 @@ class RotateTest < Minitest::Test
 
   def test_rotate
     10.times do |i|
-      User.create!(city: "City #{i}", email: "test#{i}@example.org")
+      User.create!(name: "name#{i}", city: "City #{i}", email: "test#{i}@example.org", balance: i.to_s)
     end
 
     user = User.last
@@ -21,6 +21,17 @@ class RotateTest < Minitest::Test
     assert_equal "test9@example.org", user.email
     assert_equal original_city_ciphertext, user.city_ciphertext
     refute_equal original_email_ciphertext, user.email_ciphertext
+
+    original_email_ciphertext = user.email_ciphertext
+    original_balance_ciphertext = user.balance_ciphertext
+
+    Lockbox.rotate(User, attributes: [:balance], batch_size: 5)
+
+    user = User.last
+    assert_equal "name9", user.name
+    assert_equal "test9@example.org", user.email
+    assert_equal original_email_ciphertext, user.email_ciphertext
+    refute_equal original_balance_ciphertext, user.balance_ciphertext
   end
 
   def test_rotate_relation
@@ -58,5 +69,44 @@ class RotateTest < Minitest::Test
     user = User.create!(email_ciphertext: box.encrypt(email))
     user = User.last
     assert_equal email, user.email
+  end
+
+  def test_rotation_with_associated_fields
+    # Test Previous Versions associated_field email_ciphertext with key attr
+    balance = "20"
+    email = "test@example.org"
+    key = User.lockbox_attributes[:balance][:previous_versions].first[:key]
+    email_key = User.lockbox_attributes[:email][:previous_versions].first[:key]
+    box = Lockbox.new(key: key, encode: true)
+    email_box = Lockbox.new(key: email_key, encode: true)
+
+    email_ciphertext = email_box.encrypt(email)
+    user = User.create!(
+      name: "testuser",
+      email_ciphertext: email_ciphertext,
+      balance_ciphertext: box.encrypt(balance, associated_data: email_ciphertext)
+    )
+
+    user = User.last
+
+    assert_equal email, user.email
+    assert_equal balance, user.balance
+  end
+
+  def test_rotation_with_associated_fields_mastery_key 
+    # Test Previous Versions associated_field id with master key attr
+    balance = "20"
+    email = "test@example.org"
+    name = "testuser"
+    master_key = User.lockbox_attributes[:balance][:previous_versions][1].fetch(:master_key)
+    key = Lockbox.attribute_key(table: "users", attribute: "balance_ciphertext", master_key: master_key)
+    box = Lockbox.new(key: key, encode: true)
+    user = User.create!(name: name, email: email)
+    user.update!(
+      balance_ciphertext: box.encrypt(balance, associated_data: user.id.to_s)
+    )
+
+    user = User.last
+    assert_equal balance, user.balance
   end
 end

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -83,7 +83,8 @@ class User < ActiveRecord::Base
 
   has_encrypted :state
   has_encrypted :password, with_associated_field: 'id'
- 
+  has_encrypted :balance, with_associated_field: 'name', previous_versions: [{ key: Lockbox.generate_key, with_associated_field: 'email_ciphertext' }, { master_key: Lockbox.generate_key, with_associated_field: 'id' }]
+
   has_rich_text :content if respond_to?(:has_rich_text)
 
   include PhotoUploader::Attachment(:photo)
@@ -128,6 +129,7 @@ class Admin < ActiveRecord::Base
 
   has_encrypted :email_address, key_table: "users", key_attribute: "email_ciphertext", previous_versions: [{key_table: "people", key_attribute: "email_ciphertext"}]
   has_encrypted :work_email, encrypted_attribute: "encrypted_email"
+  has_encrypted :password, encrypted_attribute: 'encrypted_password', with_associated_field: 'balance_ciphertext'
 
   attribute :code, :string, default: -> { "hello" }
 end

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -82,7 +82,8 @@ class User < ActiveRecord::Base
   has_encrypted :ssn, encode: false
 
   has_encrypted :state
-
+  has_encrypted :password, with_associated_field: 'id'
+ 
   has_rich_text :content if respond_to?(:has_rich_text)
 
   include PhotoUploader::Attachment(:photo)
@@ -90,7 +91,7 @@ end
 
 class Post < ActiveRecord::Base
   has_encrypted :title
-  validates :title, presence: true, length: {minimum: 3}
+  validates :title, presence: true, length: { minimum: 3 }
 
   if respond_to?(:has_one_attached)
     has_one_attached :photo
@@ -103,6 +104,7 @@ class Robot < ActiveRecord::Base
   serialize :properties, JSON
 
   has_encrypted :name, :email, :properties, migrating: true
+  has_encrypted :password, with_associated_field: 'id', migrating: true
 end
 
 class Comment < ActiveRecord::Base

--- a/test/support/mongoid.rb
+++ b/test/support/mongoid.rb
@@ -55,9 +55,11 @@ class Robot
   field :name_ciphertext, type: String
   field :email_ciphertext, type: String
   field :password_ciphertext, type: String
+  field :balance_ciphertext, type: String
 
   has_encrypted :name, :email, migrating: true
   has_encrypted :password, migrating: true, with_associated_field: '_id'
+  has_encrypted :balance, type: :integer, with_associated_field: 'name', previous_versions: [{ key: Lockbox.generate_key, with_associated_field: 'email_ciphertext' }, { master_key: Lockbox.generate_key, with_associated_field: '_id' }]
 end
 
 class Admin
@@ -71,6 +73,9 @@ class Admin
   field :encrypted_email, type: String
   field :dep_ciphertext, type: String
   field :dep2_ciphertext, type: String
+  field :encrypted_password, type: String
+  field :balance_ciphertext, type: String
+  field :age_ciphertext, type: String
 
   has_encrypted :email, key: :record_key
   has_encrypted :personal_email, key: -> { record_key }
@@ -82,6 +87,7 @@ class Admin
 
   has_encrypted :email_address, key_table: "users", key_attribute: "email_ciphertext", previous_versions: [{key_table: "people", key_attribute: "email_ciphertext"}]
   has_encrypted :work_email, encrypted_attribute: "encrypted_email"
+  has_encrypted :password, encrypted_attribute: 'encrypted_password', with_associated_field: 'balance_ciphertext'
 end
 
 class Agent

--- a/test/support/mongoid.rb
+++ b/test/support/mongoid.rb
@@ -15,6 +15,7 @@ class User
   field :ssn_ciphertext, type: BSON::Binary
   field :state, type: String
   field :state_ciphertext, type: String
+  field :password_ciphertext, type: String
 
   has_encrypted :email, previous_versions: [{key: Lockbox.generate_key}, {master_key: Lockbox.generate_key}]
 
@@ -24,6 +25,7 @@ class User
   has_encrypted :city, padding: true
   has_encrypted :ssn, encode: false
   has_encrypted :state
+  has_encrypted :password, with_associated_field: '_id'
 
   include PhotoUploader::Attachment(:photo)
   field :photo_data, type: String
@@ -49,10 +51,13 @@ class Robot
 
   field :name, type: String
   field :email, type: String
+  field :password, type: String
   field :name_ciphertext, type: String
   field :email_ciphertext, type: String
+  field :password_ciphertext, type: String
 
   has_encrypted :name, :email, migrating: true
+  has_encrypted :password, migrating: true, with_associated_field: '_id'
 end
 
 class Admin


### PR DESCRIPTION
### Summary
From #155 Tackling add `associated_data` option to models
To protect further our data, we can use other non-encrypted or encrypted fields to associate to the current encrypted data in our models, it adds another layer to encrypt fields. Associated fields can only be fields/columns from the same table as the field being encrypted. To use associated_fields on a encrypted field, we pass the option `:with_associated_field` 


### Changes
- Update `encrypt_method_name`, `decrypt_method_name` to accept associated_data (nil by default).
- Update Model Validations/Checks for associated_attributes 
  -  Checks for algorithm, does not allow runs in xsalsa20 or hybrid with associated data) 
  -  Checks for Looping `associated_data` e.g name requires email and email requires name
  - Checks if the same attribute is passed as associated_data
- Update `create_method`/`update_method` after creation checks for any changes in the record usually id and updates any encrypted attribute with `id` as associated data, this method is recursive meaning that if there is any encrypted updated by this changes, this method will chain itself. `(id|name) --> (name|email) --> email`  
- Update update_columns method, whenever an associated attribute is updated, cipher/encrypted fields that require that field as associated are added (This is necessary otherwise ciphers would Out of loop)
- Add associated_data methods to model (`lockbox_associated_attributes` , `lockbox_sync_associated_with_attribute`, `lockbox_sync_associated` ) used in create_record and update_record
- Update `insert_all`, `insert_all`!, `upsert_all` methods with `lockbox_map_attributes` lockbox_map_attributes attempts to insert associated encrypted fields but if the associated_data is not present this field is ignored. (This is a limitation on sqllite since insert_all does not returns the collection created.)
- Update `name` method, maps `previous_versions` associated_data and passes current encrypt associated data to decrypt method
- Update `name=` method, passes associated_data to lockbox_direct_name
- Update Pluck method, for associated attributes we need fetch the associated data to decrypt ciphertext saved in the DB. These associated columns are not returned if not passed as an arg for `pluck` 
- Add compatibility for `previous_versions`, previous_versions now allow `:with_associated_field` option, if added boxes will use the current data found in the designed field as associated_data
- Update Rotate & Migration to include associated data 
- Add `@new_boxes` to encryptor, used for decrypt fields `@new_boxes` is an array of hashes with :box and :with_associated_field/:associated_field, this allow all "boxes" to use a different associated value or no associated if not provided
- Update Tests, common tests now tests unencrypted fields, encrypted fields and encrypted fields with associated data (`password`)
- Add Tests for Associated Checks in Model and Rotate/Migrate for fields with associated data