### PR TITLE
Fix bug with different object returned on initial decryption of attribute in AR

### DIFF
--- a/lib/lockbox/model.rb
+++ b/lib/lockbox/model.rb
@@ -500,7 +500,10 @@ module Lockbox
                 # cache
                 # decrypt method does type casting
                 if respond_to?(:write_attribute_without_type_cast, true)
-                  write_attribute_without_type_cast(name.to_s, message) if !@attributes.frozen?
+                  if !@attributes.frozen?
+                    write_attribute_without_type_cast(name.to_s, message)
+                    message = @attributes[name.to_s].value
+                  end
                 elsif respond_to?(:raw_write_attribute, true)
                   raw_write_attribute(name, message) if !@attributes.frozen?
                 else

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -18,6 +18,15 @@ class ModelTest < Minitest::Test
     assert_equal email, user.email
   end
 
+  def test_object_consistency
+    settings = { 'mfa_enabled' => false }
+    User.create!(settings2: settings)
+    user = User.last
+    decrypted_settings = user.settings2
+    decrypted_settings['mfa_enabled'] = true
+    assert_equal true, user.settings2['mfa_enabled']
+  end
+
   def test_decrypt_after_destroy
     email = "test@example.org"
     User.create!(email: email)


### PR DESCRIPTION
On initial decryption of an ActiveRecord attribute, we were not returning the same object as subsequent calls to the attribute. Here is an example
```
class User < ActiveRecord::Base
  has_encrypted :foo
end

user = User.last
user.foo.object_id  # 12340
user.foo.object_id  # 12360
user.foo.object_id  # 12360 
``` 
See test in this PR for an example of an issue that I ran into!