### PR TITLE
fix #attributes not returning values for encrypted attributes in a store

### DIFF
--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -213,9 +213,10 @@ class ModelTest < Minitest::Test
   def test_attributes
     skip if mongoid?
 
-    User.create!(email: "test@example.org")
+    User.create!(email: "test@example.org", password: "Passw0rd!")
     user = User.last
     assert_equal "test@example.org", user.attributes["email"]
+    assert_equal "Passw0rd!", user.attributes["password"]
   end
 
   def test_attributes_not_loaded

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -72,9 +72,11 @@ class User < ActiveRecord::Base
     serialize :coordinates, Array
   end
 
-  store :credentials, accessors: [:username], coder: JSON
-  store :credentials2, accessors: [:username2], coder: JSON
+  store :credentials, accessors: [:username, :password_ciphertext], coder: JSON
+  store :credentials2, accessors: [:username2, :password2_ciphertext], coder: JSON
   has_encrypted :credentials2
+  has_encrypted :password
+  has_encrypted :password2
 
   attribute :configuration, Configuration.new
   has_encrypted :configuration2, type: Configuration.new


### PR DESCRIPTION
The `#attributes` Hash returned for an ActiveRecord object will return nil for lockbox attributes if the encrypted attribute is stored within an `ActiveRecord::Store`. Example using the `User` class in `test/support/active_record.rb`
```
class User < ActiveRecord::Base
  has_encrypted :email

  store :credentials, accessors: [:password_ciphertext], coder: JSON
  has_encrypted :password
end

User.create!(email: "test@example.org", password: "Passw0rd!")
user = User.last
user.attributes["email"]  # returns "test@example.org"
user.attributes["password"]  # returns nil
```

Handling this seemed quite complex, I wonder if there is an easier way!