### PR TITLE
Correctly handle missing decryption keys with callable option for "hybrid" algorithm

### DIFF
--- a/test/internal/db/schema.rb
+++ b/test/internal/db/schema.rb
@@ -131,6 +131,8 @@ ActiveRecord::Schema.define do
   create_table :agents do |t|
     t.text :name
     t.text :email_ciphertext
+    t.text :skill_ciphertext
+    t.text :specialization_ciphertext
   end
 
   create_table :people do |t|

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -501,6 +501,66 @@ class ModelTest < Minitest::Test
     assert_equal "No decryption key set", error.message
   end
 
+  def test_hybrid_no_decryption_key_in_callable
+    Agent.delete_all
+
+    agent = Agent.create!(skill: "Problem Solving")
+    original_skill_ciphertext = agent.skill_ciphertext
+    assert_equal agent, Agent.last
+
+    agent = Agent.last
+    agent.name = "Test"
+    agent.save!
+
+    agent = Agent.last
+    assert_equal original_skill_ciphertext, agent.skill_ciphertext
+
+    agent = Agent.last
+    agent.skill = "Strategic Planning"
+    agent.save!
+
+    agent = Agent.last
+    assert agent.inspect
+    assert_nil agent.attributes["skill"]
+    assert agent.attributes["skill_ciphertext"]
+
+    # TODO change to Lockbox::DecryptionError?
+    error = assert_raises(ArgumentError) do
+      agent.skill
+    end
+    assert_equal "No decryption key set", error.message
+  end
+
+  def test_hybrid_no_decryption_key_in_instance
+    Agent.delete_all
+
+    agent = Agent.create!(specialization: "Chess")
+    original_specialization_ciphertext = agent.specialization_ciphertext
+    assert_equal agent, Agent.last
+
+    agent = Agent.last
+    agent.name = "Test"
+    agent.save!
+
+    agent = Agent.last
+    assert_equal original_specialization_ciphertext, agent.specialization_ciphertext
+
+    agent = Agent.last
+    agent.specialization = "Sudoku"
+    agent.save!
+
+    agent = Agent.last
+    assert agent.inspect
+    assert_nil agent.attributes["specialization"]
+    assert agent.attributes["specialization_ciphertext"]
+
+    # TODO change to Lockbox::DecryptionError?
+    error = assert_raises(ArgumentError) do
+      agent.specialization
+    end
+    assert_equal "No decryption key set", error.message
+  end
+
   def test_validations_valid
     post = Post.new(title: "Hello World")
     assert post.valid?

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -164,6 +164,12 @@ end
 class Agent < ActiveRecord::Base
   key_pair = Lockbox.generate_key_pair
   has_encrypted :email, algorithm: "hybrid", encryption_key: key_pair[:encryption_key]
+  has_encrypted :skill, algorithm: "hybrid", encryption_key: key_pair[:encryption_key], decryption_key: -> { nil }
+  has_encrypted :specialization, algorithm: "hybrid", encryption_key: key_pair[:encryption_key], decryption_key: :record_key
+
+  def record_key
+    nil
+  end
 end
 
 class Person < ActiveRecord::Base


### PR DESCRIPTION
When the `decryption_key` option of an encrypted attribute using the `"hybrid"` algorithm is set to a Proc/Lambda or Symbol which would return `nil` an error is raised when setting the attribute.

Example:

```ruby
class Agent < ActiveRecord::Base
  has_encrypted :skill,
                             algorithm: "hybrid",
                             encryption_key: ENV["encryption_key"],
                             decryption_key: -> { fetch_decryption_key }

  def fetch_decryption_key
    # ...
  end
end
```

```ruby
agent.fetch_decryption_key # => nil
agent.skill = "Strategic Planning"  # => `ArgumentError: No decryption key set`
```

The problem is that only the presence of the option is checked e.g. here:

https://github.com/ankane/lockbox/blob/7de736d9135cfa5125fa723059cdd7ace4ee1a92/lib/lockbox/model.rb#L491

The provided fix is a bit ugly because it duplicates the the logic to retrieve the actual decryption_key, but I wasn't sure where else to put it. I'd be happy to update the code if you provide me with the place were I should put the logic to dry things up.