### PR TITLE
README update: Add a link to blind index key rotation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,8 @@ User.find_each do |user|
 end
 ```
 
+To rotate [Blind Index](https://github.com/ankane/blind_index) columns, do it as specified in that gem [documentation](https://github.com/ankane/blind_index#key-rotation).
+
 Once everything is rotated, you can remove `previous_versions` from the initializer.
 
 ### Individual Fields & Files


### PR DESCRIPTION
Description same as title.

I think it can be useful when reading the docs to rotate lockbox keys, a link to the docs to rotate blind index columns, if any.

Because blind indexes need to be rotated too, right?