### PR TITLE
Fix issue in Rails 7.1.4 preview creation 

### DIFF
--- a/lib/lockbox/active_storage_extensions.rb
+++ b/lib/lockbox/active_storage_extensions.rb
@@ -150,6 +150,18 @@ module Lockbox
     end
 
     module Blob
+      module Representable
+        def previewable?
+          !encrypted? && super
+        end
+
+        private
+
+        def encrypted?
+          metadata.fetch("encrypted", false)
+        end
+      end
+
       private
 
       def extract_content_type(io)

--- a/lib/lockbox/railtie.rb
+++ b/lib/lockbox/railtie.rb
@@ -25,6 +25,7 @@ module Lockbox
           end
           ActiveSupport.on_load(:active_storage_blob) do
             prepend Lockbox::ActiveStorageExtensions::Blob
+            prepend Lockbox::ActiveStorageExtensions::Blob::Representable
           end
         elsif ActiveStorage::VERSION::MAJOR >= 6
           ActiveSupport.on_load(:active_storage_attachment) do


### PR DESCRIPTION
A [change](https://github.com/rails/rails/pull/51030) was introduced to Rails in 7.1.4  that calls [ActiveStorage::Attachment#transform_variants_later](https://github.com/rails/rails/blob/a11f0a63673d274c59c69c2688c63ba303b86193/activestorage/app/models/active_storage/attachment.rb#L134) in an after_commit callback . 

a job is instantiated to create a preview [here](https://github.com/rails/rails/blob/a11f0a63673d274c59c69c2688c63ba303b86193/activestorage/app/models/active_storage/attachment.rb#L142) 

This was not the case in prior Rails versions.

Due to this providing there's a previewer (Poppler), a preview will attempt to be generated and results in a a read error being surfaced from pdftoppm trying to process/read the encrypted file

Lockbox, already patches calls to `preview` with an exception, however this PR introduces a method to prevent generating previews if the blob is encrypted.

[This PR](https://github.com/rails/rails/pull/51351) to Rails bypasses this issue in Rails 7.2.0 by only creating previews if there's variants, which also aren't supported by Lockbox