### PR TITLE
Load Active Storage prepends underneath Active Storage hook

### DIFF
--- a/lib/lockbox/railtie.rb
+++ b/lib/lockbox/railtie.rb
@@ -11,12 +11,11 @@ module Lockbox
       if defined?(ActiveStorage)
         require "lockbox/active_storage_extensions"
 
-        ActiveStorage::Attached.prepend(Lockbox::ActiveStorageExtensions::Attached)
-        ActiveStorage::Attached::Changes::CreateOne.prepend(Lockbox::ActiveStorageExtensions::CreateOne)
-        ActiveStorage::Attached::One.prepend(Lockbox::ActiveStorageExtensions::AttachedOne)
-        ActiveStorage::Attached::Many.prepend(Lockbox::ActiveStorageExtensions::AttachedMany)
-
         ActiveSupport.on_load(:active_storage_attachment) do
+          ActiveStorage::Attached.prepend(Lockbox::ActiveStorageExtensions::Attached)
+          ActiveStorage::Attached::Changes::CreateOne.prepend(Lockbox::ActiveStorageExtensions::CreateOne)
+          ActiveStorage::Attached::One.prepend(Lockbox::ActiveStorageExtensions::AttachedOne)
+          ActiveStorage::Attached::Many.prepend(Lockbox::ActiveStorageExtensions::AttachedMany)
           prepend Lockbox::ActiveStorageExtensions::Attachment
         end
         ActiveSupport.on_load(:active_storage_blob) do


### PR DESCRIPTION
I figure by adding those prepends under the `ActiveSupport.on_load(:active_storage_attachment)` hook, the race condition might go away, so I made a pull request for that.

I believe this resolves the issue observed in https://github.com/ankane/lockbox/issues/205