### PR TITLE
Fix ActiveStorage version comparison error

### DIFF
--- a/lib/lockbox/active_storage_extensions.rb
+++ b/lib/lockbox/active_storage_extensions.rb
@@ -135,7 +135,7 @@ module Lockbox
     end
 
     module Blob
-      if ActiveStorage::VERSION::STRING.to_f == 7.1 && ActiveStorage.version >= "7.1.4"
+      if ActiveStorage::VERSION::STRING.to_f == 7.1 && ActiveStorage::VERSION::STRING >= "7.1.4"
         def preview_image_needed_before_processing_variants?
           !instance_variable_defined?(:@lockbox_encrypted) && super
         end


### PR DESCRIPTION
Fix version comparison in ActiveStorage extensions

This PR fixes an error that occurs when comparing ActiveStorage version with a string. 
The current implementation attempts to compare a Gem::Version object with a string using 
the >= operator, which raises an ArgumentError.